### PR TITLE
シグネチャの更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ export type Result<T, E> = ResultOk<T> | ResultErr<E>;
 ## Usage
 
 ```ts
-import { Result, Ok, Err } from "@yajamon/result.ts"
+import { Result, ok, err } from "@yajamon/result.ts"
 
 class Foo {
   static create(input:string): Result<Foo, Error> {
     if (validation(input)) {
       const foo = new Foo();
       // ...
-      return Ok(foo);
+      return ok(foo);
     } else {
-      return Err(new Error("error message"));
+      return err(new Error("error message"));
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yajamon/result.ts",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Type definitions and simple functions inspired by Rust's Result.",
   "main": "lib/main.js",
   "scripts": {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, ok, Result, unwrap } from "./main";
+import { err, Err, Ok, ok, Result, unwrap } from "./main";
 
 describe("Ok", () => {
   it("is return ResultOk", () => {
@@ -30,6 +30,18 @@ describe("ok", () => {
     if (success.isError === false) {
       // isError を確認することで、スコープ内の型を ResultからResultOkに推定できる
       expect(success.value).toEqual("success");
+    } else {
+      throw "Wrong!";
+    }
+  });
+});
+
+describe("err", () => {
+  it("is return ResultErr", () => {
+    const error = err("error") as Result<never, string>;
+    if (error.isError) {
+      // isError を確認することで、スコープ内の型を ResultからResultErrに推定できる
+      expect(error.error).toEqual("error");
     } else {
       throw "Wrong!";
     }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,4 +1,4 @@
-import { Err, Ok, Result, unwrap } from "./main";
+import { Err, Ok, ok, Result, unwrap } from "./main";
 
 describe("Ok", () => {
   it("is return ResultOk", () => {
@@ -18,6 +18,18 @@ describe("Err", () => {
     if (error.isError) {
       // isError を確認することで、スコープ内の型を ResultからResultErrに推定できる
       expect(error.error).toEqual("error");
+    } else {
+      throw "Wrong!";
+    }
+  });
+});
+
+describe("ok", () => {
+  it("is return ResultOk", () => {
+    const success = ok("success") as Result<string, never>;
+    if (success.isError === false) {
+      // isError を確認することで、スコープ内の型を ResultからResultOkに推定できる
+      expect(success.value).toEqual("success");
     } else {
       throw "Wrong!";
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export type ResultErr<E> = {
 
 export type Result<T, E> = ResultOk<T> | ResultErr<E>;
 
-export const Ok: <T>(value: T) => ResultOk<T> = (v) => ({
+export const ok: <T>(value: T) => ResultOk<T> = (v) => ({
   isError: false,
   value: v,
 });
@@ -18,6 +18,9 @@ export const Err: <E>(error: E) => ResultErr<E> = (e) => ({
   isError: true,
   error: e,
 });
+
+/** @deprecated Use `ok(result: T)` instead */
+export const Ok = ok;
 
 export const unwrap: <T, E>(result: Result<T, E>) => T = (result) => {
   if (result.isError) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,13 +14,15 @@ export const ok: <T>(value: T) => ResultOk<T> = (v) => ({
   isError: false,
   value: v,
 });
-export const Err: <E>(error: E) => ResultErr<E> = (e) => ({
+export const err: <E>(error: E) => ResultErr<E> = (e) => ({
   isError: true,
   error: e,
 });
 
 /** @deprecated Use `ok(result: T)` instead */
 export const Ok = ok;
+/** @deprecated Use `err(error: E)` instead */
+export const Err = err;
 
 export const unwrap: <T, E>(result: Result<T, E>) => T = (result) => {
   if (result.isError) {


### PR DESCRIPTION
Fix #14 

- `ok(v)` と `err(e)` を追加する。
- `Ok(v)` と `Err(e)` はひとまず `deprecated` として残しておく。
